### PR TITLE
Fix redis user group def

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,7 +124,7 @@ class redis (
   $redis_pkg = "${redis_src_dir}/${redis_pkg_name}"
 
   # Install default instance
-  redis::instance { 'redis-default': 
+  redis::instance { 'redis-default':
      redis_port                    => $redis_port,
      redis_bind_address            => $redis_bind_address,
      redis_max_memory              => $redis_max_memory,
@@ -147,7 +147,7 @@ class redis (
 
   user { 'redis':
     ensure => present,
-    groups => ["redis"],
+    gid => "redis",
     require => Group["redis"],
   }
 


### PR DESCRIPTION
Upgrading from thomasvandoren/puppet-redis, I was getting the following:

```
err: /Stage[main]/Redis/User[redis]/ensure: change from absent to present failed: Could not create user redis: Execution of '/usr/sbin/useradd -G redis redis' returned 9: useradd: group redis exists - if you want to add this user to that group, use -g.
```

I think this is because I already had the redis group defined, but your user def was trying to create it, and failing to create the user when it couldn't.

Puppet docs:

```
groups

The groups to which the user belongs. The primary group should not be listed, and groups should be identified by name rather than by GID. Multiple groups should be specified as an array.
```

Note, the primary group should not be listed.

```
gid

The user’s primary group. Can be specified numerically or by name.
```

Specifying gid by name instead seems to do the trick.
