### PR TITLE
Sets DAEMON to the correct path

### DIFF
--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -6,7 +6,7 @@ REDIS_BIND_ADDRESS="<%= @redis_bind_address ? @redis_bind_address : '127.0.0.1' 
 UID=redis
 GID=redis
 
-DAEMON=/usr/bin/redis-server
+DAEMON=<%= scope.lookupvar('redis::redis_bin_dir') %>/bin/redis-server
 CLIEXEC="<%= scope.lookupvar('redis::redis_bin_dir') %>/bin/redis-cli -h $REDIS_BIND_ADDRESS -p $REDIS_PORT <%= @redis_password ? '-a ' + @redis_password : '' %>"
 PIDFILE="/var/run/redis/redis_${REDIS_PORT}.pid"
 CONF="/etc/redis/${REDIS_PORT}.conf"
@@ -86,7 +86,7 @@ status()
 
 case "$1" in
     start)
-  start 
+  start
   ;;
     stop)
   stop

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -84,7 +84,7 @@ databases <%= @redis_databases %>
 <%- if @redis_snapshotting
       @redis_snapshotting.each do |seconds,changes|
 %>
-save <%= @seconds %> <%= @changes %>
+save <%= seconds %> <%= changes %>
 <%-   end %>
 <%- end %>
 


### PR DESCRIPTION
The [application_puppet](https://github.com/opentable/puppet-modules/blob/master/otmodules/application_redis/manifests/init.pp#L23) module configures a symlink to point /usr/bin/redis-server to /opt/redis/bin/redis-server.  This isn't necessary and DAEMON should be set to the redis::redis_bin_dir.  This change shouldn't break any existing instances.