### PR TITLE
Enable tcp keepalive

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     wget: https://github.com/maestrodev/puppet-wget.git
     gcc:  https://github.com/puppetlabs/puppetlabs-gcc.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
   symlinks:
     "redis": "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source 'http://rubygems.org'
+
+
+group :development do
+  gem 'puppet', '= 3.7.5'
+  gem 'rake'
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'safe_yaml'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.4)
+      CFPropertyList (~> 2.2.6)
+    hiera (1.3.4)
+      json_pure
+    json_pure (1.8.3)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    puppet (3.7.5)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-syntax (2.0.0)
+      rake
+    puppetlabs_spec_helper (0.10.2)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (10.4.2)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-puppet (2.1.0)
+      rspec
+    rspec-support (3.2.2)
+    safe_yaml (1.0.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet (= 3.7.5)
+  puppetlabs_spec_helper
+  rake
+  rspec-puppet
+  safe_yaml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,6 +136,7 @@ class redis (
   $redis_slave_output_buffer_soft_limit = $redis::params::redis_slave_output_buffer_soft_limit,
   $redis_slave_output_buffer_soft_limit_max_interval = $redis::params::redis_slave_output_buffer_soft_limit_max_interval,
   $redis_snapshotting = $redis::params::redis_snapshotting,
+  $redis_tcp_keepalive = $redis::params::redis_tcp_keepalive,
   $manage_config_file = $redis::params::manage_config_file
 ) inherits redis::params {
 
@@ -166,6 +167,7 @@ class redis (
      redis_slave_output_buffer_soft_limit              => $redis_slave_output_buffer_soft_limit,
      redis_slave_output_buffer_soft_limit_max_interval => $redis_slave_output_buffer_soft_limit_max_interval,
      redis_snapshotting                                => $redis_snapshotting,
+     redis_tcp_keepalive                               => $redis_tcp_keepalive,
      manage_config_file                                => $manage_config_file
  }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -118,6 +118,7 @@ define redis::instance (
   $redis_slave_output_buffer_soft_limit = $redis::params::redis_slave_output_buffer_soft_limit,
   $redis_slave_output_buffer_soft_limit_max_interval = $redis::params::redis_slave_output_buffer_soft_limit_max_interval,
   $redis_snapshotting = $redis::params::redis_snapshotting,
+  $redis_tcp_keepalive = $redis::params::redis_tcp_keepalive,
   $manage_config_file = $redis::params::manage_config_file
   ) {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,5 +35,6 @@ class redis::params {
   $redis_slave_output_buffer_soft_limit = '64mb'
   $redis_slave_output_buffer_soft_limit_max_interval = 60
   $redis_snapshotting = { '900' => '1', '300' => '10', '60' => '10000' }
+  $redis_tcp_keepalive = 60
   $manage_config_file = false
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,8 +31,8 @@ class redis::params {
   $redis_slaveof_master_port = 6379
   $redis_repl_backlog_size = undef
   $redis_slave_priority = 100
-  $redis_slave_output_buffer_hard_limit = 256mb
-  $redis_slave_output_buffer_soft_limit = 64mb
+  $redis_slave_output_buffer_hard_limit = '256mb'
+  $redis_slave_output_buffer_soft_limit = '64mb'
   $redis_slave_output_buffer_soft_limit_max_interval = 60
   $redis_snapshotting = { '900' => '1', '300' => '10', '60' => '10000' }
   $manage_config_file = false

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -50,10 +50,16 @@ describe 'redis::instance', :type => 'define' do
       }
     end # let
 
+    let :facts do
+      {
+          :osfamily  => 'Debian'
+      }
+    end # let
+
     it do
       should contain_file('redis_port_6900.conf').with_content(/^port 6900$/)
-      should contain_file('redis_port_6900.conf').with_content(/^pidfile \/var\/run\/redis_6900\.pid$/)
-      should contain_file('redis_port_6900.conf').with_content(/^logfile \/var\/log\/redis_6900\.log$/)
+      should contain_file('redis_port_6900.conf').with_content(/pidfile \/var\/run\/redis\/redis_6900\.pid/)
+      should contain_file('redis_port_6900.conf').with_content(/^logfile \/var\/log\/redis\/redis_6900\.log$/)
       should contain_file('redis_port_6900.conf').with_content(/^dir \/var\/lib\/redis\/6900$/)
       should contain_file('redis-init-6900').with_content(/^REDIS_PORT="6900"$/)
     end # it
@@ -64,6 +70,12 @@ describe 'redis::instance', :type => 'define' do
       {
         :redis_port => '6900',
         :redis_bind_address => '10.1.2.3'
+      }
+    end # let
+
+    let :facts do
+      {
+          :osfamily  => 'Debian'
       }
     end # let
 

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -37,6 +37,24 @@ bind <%= @redis_bind_address %>
 # Close the connection after a client is idle for N seconds (0 to disable)
 timeout <%= @redis_timeout %>
 
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Take the connection alive from the point of view of network
+#    equipment in the middle.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 60 seconds.
+<% if @redis_tcp_keepalive %>
+tcp-keepalive <%= @redis_tcp_keepalive %>
+<% end %>
+
 # Set server verbosity to 'debug'
 # it can be one of:
 # debug (a lot of information, useful for development/testing)

--- a/templates/redis_port.conf.erb
+++ b/templates/redis_port.conf.erb
@@ -82,9 +82,8 @@ databases <%= @redis_databases %>
 #   Note: you can disable saving at all commenting all the save lines.
 
 <%- if @redis_snapshotting
-      @redis_snapshotting.each do |seconds,changes|
-%>
-save <%= @seconds %> <%= @changes %>
+      @redis_snapshotting.each do |seconds,changes| %>
+save <%= seconds %> <%= changes %>
 <%-   end %>
 <%- end %>
 


### PR DESCRIPTION
This is a remake of https://github.com/opentable/puppet-redis/pull/13 with a cleaned up commit history.

Allow TCP keepalive as a config option
Fix the rspec tests
Fix a bug in the config erb regarding snapshotting.
